### PR TITLE
Fix annotation name for multus network-status.

### DIFF
--- a/code/assignPodAddress.py
+++ b/code/assignPodAddress.py
@@ -21,7 +21,7 @@ class WorkerNodeManager(object):
         self.NetworkingData={}
         self.ec2ClientArr={}
         self.tags={}
-        self.clusterName=None        
+        self.clusterName=None
         if not self.instance_id or not self.region or not self.hostname:
             Exception("WorkerNodeManager: __init__" + " failed to get instanceid,hostname region data from worker metadata")
         ec2_client = boto3.client('ec2', region_name=self.region)
@@ -31,23 +31,23 @@ class WorkerNodeManager(object):
         for cidr in self.NetworkingData:
             k = boto3.client('ec2', region_name=self.region)
             self.ec2ClientArr[cidr] = k
-        ### Featch instance Tags    
-        get_instanceTags(ec2_client,self.instance_id,self.tags)    
+        ### Featch instance Tags
+        get_instanceTags(ec2_client,self.instance_id,self.tags)
         self.clusterName=getEKSClusterNameFromTag(self.tags)
     def getInstaceId(self):
-        return self.instance_id          
+        return self.instance_id
     def getRegion(self):
         return self.region
     def getHostname(self):
         return self.hostname
     def getEKSClusterName(self):
-        return self.clusterName    
+        return self.clusterName
     def getNetworkingData(self):
-        return self.NetworkingData   
+        return self.NetworkingData
     def getEc2ClientArr(self):
-        return  self.ec2ClientArr    
+        return  self.ec2ClientArr
 
-### Class representing Kubenrnetes/EKS manager & fetches kubernetes/EKS related details  
+### Class representing Kubenrnetes/EKS manager & fetches kubernetes/EKS related details
 # This class is used to run kubernetes commands on the EKS cluster
 class Kubernetesmanager(object):
     def __init__(self,region,cluster,roleARN=None):
@@ -55,60 +55,60 @@ class Kubernetesmanager(object):
         self.cluster= cluster
         ### update the kubeconfig with EKS cluster details
         if roleARN:
-             kubeconfigcmd="aws eks --region " + self.region+ " update-kubeconfig --name "+ self.cluster + " --role-arn " + roleARN           
-        else:    
+             kubeconfigcmd="aws eks --region " + self.region+ " update-kubeconfig --name "+ self.cluster + " --role-arn " + roleARN
+        else:
             kubeconfigcmd="aws eks --region " + self.region+ " update-kubeconfig --name "+ self.cluster
-        tprint("Kubernetesmanager:__init__","EKS command:" + kubeconfigcmd)    
+        tprint("Kubernetesmanager:__init__","EKS command:" + kubeconfigcmd)
         output = shell_run_cmd_old(kubeconfigcmd)
         if output:
             contexts, active_context = config.list_kube_config_contexts()
             if not active_context:
-                raise Exception("Kubernetesmanager:__init__","Fatal!!! couldnt set active kubernetes context, kubeconfig is not set")  
+                raise Exception("Kubernetesmanager:__init__","Fatal!!! couldnt set active kubernetes context, kubeconfig is not set")
         else:
-                raise Exception("Kubernetesmanager:__init__","Fatal!!! Got Error for " + kubeconfigcmd)  
+                raise Exception("Kubernetesmanager:__init__","Fatal!!! Got Error for " + kubeconfigcmd)
         self.active_context = active_context
         config.load_kube_config()
         self.api_instance = client.CoreV1Api()
-    ### function to refresh the kubeconfig token    
+    ### function to refresh the kubeconfig token
     def refresh(self):
         config.load_kube_config()
-        self.api_instance = client.CoreV1Api()  
+        self.api_instance = client.CoreV1Api()
 
-    ### function to fetch the multus IP addresses & the mac-addresses from a pod (with a namespace) which has the multus annotations 
-    #    k8s.v1.cni.cncf.io/networks-status     
+    ### function to fetch the multus IP addresses & the mac-addresses from a pod (with a namespace) which has the multus annotations
+    #    k8s.v1.cni.cncf.io/network-status
 
     def getMultusIps(self,name,namespace,ipAddress):
         pretty = 'pretty_example' # str | If 'true', then the output is pretty printed. (optional)
         try:
-            api_response = self.api_instance.read_namespaced_pod(name, namespace, pretty=pretty)  
-            js = json.loads(api_response.metadata.annotations['k8s.v1.cni.cncf.io/networks-status'])
+            api_response = self.api_instance.read_namespaced_pod(name, namespace, pretty=pretty)
+            js = json.loads(api_response.metadata.annotations['k8s.v1.cni.cncf.io/network-status'])
             for i in js:
                 if  'interface' in i:
-                    for j in i['ips'] : 
-                        ipAddress[j] = i['mac']              
+                    for j in i['ips'] :
+                        ipAddress[j] = i['mac']
         except ApiException as e:
-            tprint("Kubernetesmanager:getMultusIps","Exception when calling CoreV1Api->read_namespaced_pod: %s\n" % e)        
+            tprint("Kubernetesmanager:getMultusIps","Exception when calling CoreV1Api->read_namespaced_pod: %s\n" % e)
             config.load_kube_config()
             self.api_instance = client.CoreV1Api()
-### class to handle Multus IP addresses and related handlings            
+### class to handle Multus IP addresses and related handlings
 class MultusHandler(object):
     def __init__(self,workerName,region,cluster,roleARN=None):
         self.workerName=workerName
         self.myKbernetesmgr=Kubernetesmanager(region=region,cluster=cluster,roleARN=roleARN)
         self.cmd="kubectl get pods -o=jsonpath='{range .items[?(@.metadata.annotations.k8s\.v1\.cni\.cncf\.io/networks)]}{.metadata.name}{\" \"}{@.metadata.namespace}{\" \"}{@.spec.nodeName}{\"\\n\"}' "
         self.multusNadcmd="kubectl get net-attach-def -o=jsonpath='{range .items[*]}{.metadata.name}{\" \"}{.metadata.namespace}{\"\\n\"}' "
-        self.multusPods={}    
+        self.multusPods={}
         self.multsNads={}
         self.multusNs=set()
     def refresh(self):
         self.myKbernetesmgr.refresh()
 
     ### Function to get multus NetworkAttachmentDefinitions across all the namespaces/given namespace
-    def getMultusNads(self,ns="--all-namespaces"):    
-        try:   
+    def getMultusNads(self,ns="--all-namespaces"):
+        try:
             if ns=="--all-namespaces":
                 output = shell_run_cmd_old(self.multusNadcmd + "--all-namespaces") #shell_run_cmd_old(cmd,retCode)
-            else: 
+            else:
                 output = shell_run_cmd_old(self.multusNadcmd + " -n "+ ns) #shell_run_cmd_old(cmd,retCode)
             if output:
                 output = output.rstrip()
@@ -120,24 +120,24 @@ class MultusHandler(object):
                         self.multsNads[data[0]] = { "namespace" : data[1] }
                         self.multusNs.add(data[1])
                     else:
-                        raise Exception(line + " doesnt contain all 2 fileds, name namespace")  
+                        raise Exception(line + " doesnt contain all 2 fileds, name namespace")
             else:
                 tprint("MultusHandler:getMultusNads", "Empty NAD output" + output)
         except Exception as e:
-            tprint ("MultusHandler:getMultusNads", "Exception:" + str(e) )       
-        return self.multsNads   
-    ### function to get all the namespaces which are hosting NetworkAttachmentDefinitions    
-    def getmultusNS(self):   
-        self.getMultusNads("--all-namespaces")      
+            tprint ("MultusHandler:getMultusNads", "Exception:" + str(e) )
+        return self.multsNads
+    ### function to get all the namespaces which are hosting NetworkAttachmentDefinitions
+    def getmultusNS(self):
+        self.getMultusNads("--all-namespaces")
         return self.multusNs
     def getMultusPodNamesOnWorker(self,nsSet=None):
         self.multusPods.clear()
         for ns in nsSet:
-            try:   
+            try:
                 if ns=="--all-namespaces":
                     output = shell_run_cmd_old(self.cmd + "--all-namespaces") #shell_run_cmd_old(cmd,retCode)
-                else: 
-                    output = shell_run_cmd_old(self.cmd + " -n "+ ns) #shell_run_cmd_old(cmd,retCode)                
+                else:
+                    output = shell_run_cmd_old(self.cmd + " -n "+ ns) #shell_run_cmd_old(cmd,retCode)
                 if output:
                     output = output.rstrip()
                     allPodList=output.split("\n")
@@ -150,11 +150,11 @@ class MultusHandler(object):
                                 self.myKbernetesmgr.getMultusIps(name=data[0],namespace=data[1],ipAddress=ipAddress)
                                 self.multusPods[data[0]] = { "namespace" : data[1] , "ipAddress": ipAddress }
                         else:
-                            raise Exception(line + " doesnt contain all 3 fileds, podname namespace workername")    
+                            raise Exception(line + " doesnt contain all 3 fileds, podname namespace workername")
                 else:
                     tprint("MultusHandler:getMultusPodNamesOnWorker", "Empty  Multus Pod list " + output)
             except Exception as e:
-                tprint ("MultusHandler:getMultusPodNamesOnWorker","Exception" + str(e))       
+                tprint ("MultusHandler:getMultusPodNamesOnWorker","Exception" + str(e))
         return self.multusPods
 class MultusPod(object):
     def __init__(self,name,namespace,ipDict):
@@ -170,13 +170,13 @@ class MultusPod(object):
     def getcurrIPList(self):
         return self.currIPList
     def setcurrIPList(self,currIPList):
-        self.currIPList = currIPList       
+        self.currIPList = currIPList
     def getprevIPList(self):
-        return self.prevIPList       
+        return self.prevIPList
     def setprevIPList(self,prevIPList):
-        self.prevIPList = prevIPList  
+        self.prevIPList = prevIPList
     def __str__(self) :
-        return self.name+ " " +self.namespace + str(self.ipDict)                 
+        return self.name+ " " +self.namespace + str(self.ipDict)
 def getEKSClusterNameFromTag(tags):
     clusterName=None
     any(key.startswith("kubernetes.io/cluster/") for key in tags)
@@ -207,18 +207,18 @@ try:
     workerENIData=myWorkerNode.getNetworkingData()
     ec2ClientArr=myWorkerNode.getEc2ClientArr()
 except Exception as e:
-    tprint("func:Main",str(e)+ " Exiting!!")    
+    tprint("func:Main",str(e)+ " Exiting!!")
     exit(1)
 
-ctrRefreshTime=300 
-tokenRefreshTime=30   
-ctr=0    
+ctrRefreshTime=300
+tokenRefreshTime=30
+ctr=0
 while(1):
     if (ctr % tokenRefreshTime) == 0:
         myMultusMgr.refresh()
     if ctr == 0 :
          tprint("func:Main","Preiodic check .. Log Entry before the multus query, to check the query time taken")
-    if podSearchQuery != "ALL":     
+    if podSearchQuery != "ALL":
         multusNs=myMultusMgr.getmultusNS()
     if multusNs:
         multusPods=myMultusMgr.getMultusPodNamesOnWorker(nsSet=multusNs)
@@ -226,13 +226,13 @@ while(1):
         allns={"--all-namespaces"}
         multusPods=myMultusMgr.getMultusPodNamesOnWorker(allns)
     if ctr == 0 :
-         tprint("func:Main","Preiodic check .. Log Entry after the multus query, to check the query time taken")   
+         tprint("func:Main","Preiodic check .. Log Entry after the multus query, to check the query time taken")
     for pod in multusPods.keys():
         newIPList=list(multusPods[pod]["ipAddress"].keys())
         obj= MultusPod(pod,multusPods[pod]["namespace"],multusPods[pod]["ipAddress"])
         ipmap = defaultdict(list)
         ip6map = defaultdict(list)
-        noChange=True       
+        noChange=True
         if pod in currPods.keys():
             if set(currPods[pod].getcurrIPList()) == set(newIPList):
                 pass #tprint("func:Main", "No IP change for pod " + pod)
@@ -241,18 +241,18 @@ while(1):
                 tprint("func:Main", "IP change for pod " + str(newIPList))
         else:
             noChange=False
-        if noChange==False:    
+        if noChange==False:
             tprint("func:Main","working on pod :" + str(obj))
             for ipaddress in newIPList:
-                for cidr in workerENIData.keys():  
-                    if IPAddress(ipaddress) in list(IPNetwork(cidr)):                   
-                        if  netaddr.valid_ipv4(str(ipaddress)):    
+                for cidr in workerENIData.keys():
+                    if IPAddress(ipaddress) in list(IPNetwork(cidr)):
+                        if  netaddr.valid_ipv4(str(ipaddress)):
                             ipmap[cidr].append(str(ipaddress))
                         else :
                             ip6map[cidr].append(str(ipaddress))
             manageParallelIPv4(ipmap,workerENIData,ec2ClientArr)
-            currPods[pod]=obj  
-    ctr=ctr+1   
+            currPods[pod]=obj
+    ctr=ctr+1
     if ctr == ctrRefreshTime:
-        ctr=0     
-    time.sleep(1)    
+        ctr=0
+    time.sleep(1)


### PR DESCRIPTION
Adding the annotation "networks-status" was a mistake. Regarding to the spec it's called "network-status" (singular). See: https://github.com/k8snetworkplumbingwg/multus-cni/issues/196.

*Issue #, if available:*

The multus project deprecated and removed the wrong annotation "networks-status" (plura)

*Description of changes:*

This change uses the right annotation.

It also removes trailing whitespaces (vim default).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
